### PR TITLE
Fix #upToAll: not handling encoded text streams correctly

### DIFF
--- a/.squot
+++ b/.squot
@@ -1,13 +1,13 @@
 OrderedDictionary {
-	'src\/FS-Core.package' : #SquotCypressCodeSerializer,
-	'src\/FS-Memory.package' : #SquotCypressCodeSerializer,
-	'src\/FS-Disk.package' : #SquotCypressCodeSerializer,
-	'src\/FS-AnsiStreams.package' : #SquotCypressCodeSerializer,
-	'src\/FS-FileDirectory-Adapters.package' : #SquotCypressCodeSerializer,
-	'src\/FS-Help.package' : #SquotCypressCodeSerializer,
-	'src\/FS-Tests-Core.package' : #SquotCypressCodeSerializer,
-	'src\/FS-Tests-Memory.package' : #SquotCypressCodeSerializer,
-	'src\/FS-Tests-Disk.package' : #SquotCypressCodeSerializer,
-	'src\/FS-Tests-AnsiStreams.package' : #SquotCypressCodeSerializer,
-	'src\/BaselineOfFileSystem.package' : #SquotCypressCodeSerializer
+	'src/FS-Core.package' : #SquotCypressCodeSerializer,
+	'src/FS-Memory.package' : #SquotCypressCodeSerializer,
+	'src/FS-Disk.package' : #SquotCypressCodeSerializer,
+	'src/FS-AnsiStreams.package' : #SquotCypressCodeSerializer,
+	'src/FS-FileDirectory-Adapters.package' : #SquotCypressCodeSerializer,
+	'src/FS-Help.package' : #SquotCypressCodeSerializer,
+	'src/FS-Tests-Core.package' : #SquotCypressCodeSerializer,
+	'src/FS-Tests-Memory.package' : #SquotCypressCodeSerializer,
+	'src/FS-Tests-Disk.package' : #SquotCypressCodeSerializer,
+	'src/FS-Tests-AnsiStreams.package' : #SquotCypressCodeSerializer,
+	'src/BaselineOfFileSystem.package' : #SquotCypressCodeSerializer
 }

--- a/src/FS-AnsiStreams.package/FSReadStream.class/instance/upToPosition..st
+++ b/src/FS-AnsiStreams.package/FSReadStream.class/instance/upToPosition..st
@@ -1,0 +1,9 @@
+accessing
+upToPosition: anInteger
+	"Answer a subcollection containing items starting from the current position and ending including the given position. Usefully different to #next: in that in the case of MultiByteFileStream, and perhaps others, positions measure in terms of encoded items, while #next: convention is to name a number of items, independent of their encoding in the underlying buffer."
+	
+	isBinary ifTrue: [^ self next: anInteger].
+	
+	^ String streamContents: [ :stream | | ch |
+		[(self position >= anInteger) or: [(ch := self next) == nil]]
+			whileFalse: [stream nextPut: ch]]

--- a/src/FS-AnsiStreams.package/FSReadStream.class/methodProperties.json
+++ b/src/FS-AnsiStreams.package/FSReadStream.class/methodProperties.json
@@ -20,4 +20,5 @@
 		"peekFor:" : "jr 2/21/2017 14:18",
 		"size" : "CamilloBruni 8/12/2011 20:49",
 		"skip:" : "jr 1/1/2019 18:42",
-		"upToEnd" : "jr 4/13/2017 16:30" } }
+		"upToEnd" : "jr 4/13/2017 16:30",
+		"upToPosition:" : "tobe 10/7/2020 10:21" } }

--- a/src/FS-AnsiStreams.package/TPositionableStream.trait/properties.json
+++ b/src/FS-AnsiStreams.package/TPositionableStream.trait/properties.json
@@ -1,5 +1,4 @@
 {
 	"category" : "FS-AnsiStreams",
-	"comment" : "",
 	"commentStamp" : "",
 	"name" : "TPositionableStream" }

--- a/src/FS-AnsiStreams.package/TReadableStream.trait/properties.json
+++ b/src/FS-AnsiStreams.package/TReadableStream.trait/properties.json
@@ -1,5 +1,4 @@
 {
 	"category" : "FS-AnsiStreams",
-	"comment" : "",
 	"commentStamp" : "",
 	"name" : "TReadableStream" }

--- a/src/FS-AnsiStreams.package/TWritableStream.trait/properties.json
+++ b/src/FS-AnsiStreams.package/TWritableStream.trait/properties.json
@@ -1,5 +1,4 @@
 {
 	"category" : "FS-AnsiStreams",
-	"comment" : "",
 	"commentStamp" : "",
 	"name" : "TWritableStream" }

--- a/src/FS-Tests-AnsiStreams.package/FSReadStreamTest.class/instance/testUtf8Character.st
+++ b/src/FS-Tests-AnsiStreams.package/FSReadStreamTest.class/instance/testUtf8Character.st
@@ -1,0 +1,6 @@
+tests
+testUtf8Character
+
+	self contents: 'π [' utf8Encoded.
+	stream text.
+	self assert: 'π ' equals: (stream upToAll: '[')

--- a/src/FS-Tests-AnsiStreams.package/FSReadStreamTest.class/methodProperties.json
+++ b/src/FS-Tests-AnsiStreams.package/FSReadStreamTest.class/methodProperties.json
@@ -27,4 +27,5 @@
 		"testSkipToTrue" : "cwp 7/30/2009 23:25",
 		"testUpTo" : "cwp 7/30/2009 23:38",
 		"testUpToEnd" : "jr 4/13/2017 16:30",
-		"testUpToPastEnd" : "jr 4/13/2017 16:29" } }
+		"testUpToPastEnd" : "jr 4/13/2017 16:29",
+		"testUtf8Character" : "tobe 10/7/2020 10:21" } }


### PR DESCRIPTION
`#upToAll:`'s method comment states that it is aware of multibyte encodings. I essentially just copied the relevant from MultiByteFileStream's implementation here.

Concerning the noise in the STON files: I can revert these; however, our updated STON version will always produce these changes. So we can either keep them in here or instead push an update to just the STON files to master first. What do you prefer?