### PR TITLE
Fix empty block syntax

### DIFF
--- a/src/FS-Tests-Core.package/FSReferenceTest.class/instance/testReadStreamDoNotFound.st
+++ b/src/FS-Tests-Core.package/FSReferenceTest.class/instance/testReadStreamDoNotFound.st
@@ -3,5 +3,5 @@ testReadStreamDoNotFound
 	| ref |
 	ref := filesystem / 'plonk'.
 	self
-		should: [ref readStreamDo: [:s]]
-		raise: FileDoesNotExist 
+		should: [ref readStreamDo: [:s |]]
+		raise: FileDoesNotExist

--- a/src/FS-Tests-Core.package/FSReferenceTest.class/methodProperties.json
+++ b/src/FS-Tests-Core.package/FSReferenceTest.class/methodProperties.json
@@ -46,7 +46,7 @@
 		"testPathRelativeTo" : "CamilloBruni 8/12/2011 15:48",
 		"testReadStream" : "cwp 2/26/2011 18:11",
 		"testReadStreamDo" : "cwp 2/18/2011 16:17",
-		"testReadStreamDoNotFound" : "jr 3/5/2017 13:14",
+		"testReadStreamDoNotFound" : "ct 12/29/2021 20:27",
 		"testReadStreamDoifAbsent" : "cwp 2/18/2011 16:17",
 		"testReadStreamDoifAbsentNot" : "CamilloBruni 8/12/2011 15:47",
 		"testReadStreamIfAbsent" : "cwp 2/26/2011 18:11",


### PR DESCRIPTION
It is disputed whether this syntax should be valid, but Shout does not detect it, so it might be better not to use it: http://forum.world.st/The-Inbox-ShoutCore-ct-69-mcz-td5102398.html